### PR TITLE
Copy install files to zip from product/root/install for legacy devices with custom-dt install files

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -4677,6 +4677,8 @@ ifneq (,$(INSTALLED_RECOVERYIMAGE_TARGET)$(filter true,$(BOARD_USES_RECOVERY_AS_
 	@# OTA install helpers
 	$(hide) $(call package_files-copy-root, \
 	    $(TARGET_OUT)/install,$(zip_root)/INSTALL)
+	$(hide) $(call package_files-copy-root, \
+	    $(PRODUCT_OUT)/install,$(zip_root)/INSTALL)
 ifdef INSTALLED_KERNEL_TARGET
 	cp $(INSTALLED_KERNEL_TARGET) $(zip_root)/$(PRIVATE_RECOVERY_OUT)/
 endif


### PR DESCRIPTION
Commit a17e4e3b moved the source dir from $OUT/install to system/install
as a temporary workaround because it claims that on android 11, the
build system cannot copy to $OUT/install. However, in my tests it
copies from $OUT/install just fine.

The workaround works fine for small scripts like backuptool.sh, but
it breaks compile for larger blobs (firmware, for example) that do
not physically fit in /system due to limited space on non-dynamic
devices.

Therefore, add an extra line to copy from $OUT/install, in addition
to the existing workaround of system/install.

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>
Signed-off-by: Hưng Phan <phandinhhungvp2001@gmail.com>