### PR TITLE
Bump Security String to 2022-01-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -246,7 +246,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-12-05
+      PLATFORM_SECURITY_PATCH := 2022-01-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -246,7 +246,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2022-01-05
+      PLATFORM_SECURITY_PATCH := 2022-02-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -246,7 +246,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2022-03-05
+      PLATFORM_SECURITY_PATCH := 2022-04-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -246,7 +246,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2022-02-05
+      PLATFORM_SECURITY_PATCH := 2022-03-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0643   A-183612370  ID     High       10, 11, 12
CVE-2021-30353  A-202025599  RA     High
CVE-2021-39620  A-203847542  EoP    High       11, 12
CVE-2021-39621  A-185126319  EoP    High       9, 10, 11, 12
CVE-2021-39623  A-194105348  EoP    High       9, 10, 11, 12
CVE-2021-39626  A-194695497  EoP    High       9, 10, 11, 12
CVE-2021-39627  A-185126549  EoP    High       9, 10, 11, 12
CVE-2021-39628  A-189575031  ID     High       10, 11
CVE-2021-39629  A-197353344  EoP    High       9, 10, 11, 12
CVE-2021-39632  A-202159709  EoP    High       11, 12
CVE-2021-39659  A-208267659  DoS    High       10, 11, 12

Previously Implemented:
=======================
None

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0338   A-123700107  ID     High       9, 10
CVE-2021-39618  A-196855999  EoP    High       9, 10, 11, 12 (Pixel blobs)
CVE-2021-39622  A-192663648  EoP    High       10, 11, 12 (Pixel blobs)
CVE-2021-39625  A-194695347  EoP    High       9, 10, 11, 12 (Pixel blobs)
CVE-2021-39630  A-202768292  EoP    High       12

Change-Id: I9c1d84541a92e102dee926954a90710f1beb09b1